### PR TITLE
Delay required to allow sensor to come online.

### DIFF
--- a/examples/thermal_cam_interpolate/thermal_cam_interpolate.ino
+++ b/examples/thermal_cam_interpolate/thermal_cam_interpolate.ino
@@ -147,6 +147,7 @@ void setup() {
   }
     
   Serial.println("-- Thermal Camera Test --");
+  delay(100); // let sensor boot up
 }
 
 void loop() {


### PR DESCRIPTION
Symptom is a blue screen of nothingness

A single added delay statement during setup()

I encountered this while building the [Thermal Camera With Display](https://learn.adafruit.com/thermal-camera-with-display). The screen showed all blue. This fix was found in the forums.