### PR TITLE
Fix calculation of negative temperatures read from pixels

### DIFF
--- a/Adafruit_AMG88xx.cpp
+++ b/Adafruit_AMG88xx.cpp
@@ -193,7 +193,7 @@ void Adafruit_AMG88xx::readPixels(float *buf, uint8_t size)
 		uint8_t pos = i << 1;
 		recast = ((uint16_t)rawArray[pos + 1] << 8) | ((uint16_t)rawArray[pos]);
 		
-		converted = signedMag12ToFloat(recast) * AMG88xx_PIXEL_TEMP_CONVERSION;
+		converted = twosComplementMag12ToFloat(recast) * AMG88xx_PIXEL_TEMP_CONVERSION;
 		buf[i] = converted;
 	}
 }
@@ -291,4 +291,16 @@ float Adafruit_AMG88xx::signedMag12ToFloat(uint16_t val)
 	uint16_t absVal = (val & 0x7FF);
 	
 	return (val & 0x8000) ? 0 - (float)absVal : (float)absVal ;
+}
+
+/**************************************************************************/
+/*! 
+    @brief  convert a 12-bit two's complement value to a floating point number
+    @param  val the 12-bit two's complement value to be converted
+    @returns the converted floating point value
+*/
+/**************************************************************************/
+float Adafruit_AMG88xx::twosComplementMag12ToFloat(uint16_t val)
+{
+	return (val & 0x800) ? (float)(val - 0x1000) : (float)val ;
 }

--- a/Adafruit_AMG88xx.h
+++ b/Adafruit_AMG88xx.h
@@ -115,6 +115,7 @@ class Adafruit_AMG88xx {
 		void _i2c_init();
 		
 		float signedMag12ToFloat(uint16_t val);
+		float twosComplementMag12ToFloat(uint16_t val);
 		
 		 // The power control register
         struct pctl {


### PR DESCRIPTION
The temperature values of the pixels are signed 12 bit numbers,
represented in two's complement form.
See page 14 in the specification sheet of the sensor.

I adapted the conversion of the pixel temperature values.

I got the idea for this fix from the following thread, which discusses basically the same problem, only for the python library:
https://forums.adafruit.com/viewtopic.php?f=8&t=127137
This thread also references the sensor datasheet: https://cdn-learn.adafruit.com/assets/assets/000/043/261/original/Grid-EYE_SPECIFICATIONS%28Reference%29.pdf

- I tested the change with some cold things from my fridge, and the sensor shows correct values below 0°C.
- Note that when putting cold things very close to the sensor, the sensor shows values down to -50°C, which is clearly wrong, but I think that's rather a problem of the sensor. The temperature decrease is monotonic, the values seems way more plausible than the ~500°C before the change.
- I did not change the conversion of the thermistor reads, but someone might want to look at that - I'm not sure if that is correct either (comparing the Python implementation to this one, that is)