### PR TITLE
Fix examples to make use of all colors in array.

### DIFF
--- a/examples/thermal_cam/thermal_cam.ino
+++ b/examples/thermal_cam/thermal_cam.ino
@@ -102,7 +102,7 @@ void loop() {
   amg.readPixels(pixels);
 
   for(int i=0; i<AMG88xx_PIXEL_ARRAY_SIZE; i++){
-    uint8_t colorIndex = map(pixels[i], MINTEMP, MAXTEMP, 0, 255);
+    uint8_t colorIndex = map(pixels[i] * 100, MINTEMP * 100, MAXTEMP * 100, 0, 255); //move decimal point of pixels[] two places to the right, otherwise colors are only mapped to full degrees and not points.
     colorIndex = constrain(colorIndex, 0, 255);
 
     //draw the pixels!

--- a/examples/thermal_cam_featherwing/thermal_cam_featherwing.ino
+++ b/examples/thermal_cam_featherwing/thermal_cam_featherwing.ino
@@ -139,12 +139,12 @@ void loop() {
   
   for(int i=0; i<AMG88xx_PIXEL_ARRAY_SIZE; i++){
 
-    int colorTemp;
+    float colorTemp; // May have to be moved to global?
     if(pixels[i] >= MAXTEMP) colorTemp = MAXTEMP;
     else if(pixels[i] <= MINTEMP) colorTemp = MINTEMP;
     else colorTemp = pixels[i];
     
-    uint8_t colorIndex = map(colorTemp, MINTEMP, MAXTEMP, 0, 255);
+    uint8_t colorIndex = map(colorTemp * 100, MINTEMP * 100, MAXTEMP * 100, 0, 255); // move decimal point of colorTemp 2 places to the right, otherwise colors are only mapped to full degrees and not points
     
     colorIndex = constrain(colorIndex, 0, 255);
     //draw the pixels!

--- a/examples/thermal_cam_interpolate/thermal_cam_interpolate.ino
+++ b/examples/thermal_cam_interpolate/thermal_cam_interpolate.ino
@@ -180,7 +180,7 @@ void loop() {
 }
 
 void drawpixels(float *p, uint8_t rows, uint8_t cols, uint8_t boxWidth, uint8_t boxHeight, boolean showVal) {
-  int colorTemp;
+  float colorTemp;  // changed to float
   for (int y=0; y<rows; y++) {
     for (int x=0; x<cols; x++) {
       float val = get_point(p, rows, cols, x, y);
@@ -188,7 +188,7 @@ void drawpixels(float *p, uint8_t rows, uint8_t cols, uint8_t boxWidth, uint8_t 
       else if(val <= MINTEMP) colorTemp = MINTEMP;
       else colorTemp = val;
       
-      uint8_t colorIndex = map(colorTemp, MINTEMP, MAXTEMP, 0, 255);
+      uint8_t colorIndex = map(colorTemp * 100, MINTEMP * 100, MAXTEMP * 100, 0, 255);  // move decimal point of colorTemp 2 places to the right, otherwise colors are only mapped to full degrees and not points
       colorIndex = constrain(colorIndex, 0, 255);
       //draw the pixels!
       uint16_t color;


### PR DESCRIPTION
### The examples provided do not make use of all available 255 colors in the array.
*This is because the map () function converts pixels[] to an int, resulting in a different color for every full degree shown on screen. The result is the absolute maximum number of differet colors that can be shown on screen at any one time is the difference between MAXTEMP and MINTEMP in whole numbers (for example, if MINTEMP= 25 and MAXTEMP = 35, only 10 different colors from the array can be used at any one time).*

### Solution
*The solution is very simple, inside the map() function, multiply pixels[], mintemp, and maxtemp by 100, this moves the decimal point of the float 2 places to the right. The resulting whole number is then mapped to colorIndex, which will result in the full color array being used.*
