### PR TITLE
Add method to read the pixels' raw registers

### DIFF
--- a/Adafruit_AMG88xx.cpp
+++ b/Adafruit_AMG88xx.cpp
@@ -171,20 +171,20 @@ float Adafruit_AMG88xx::readThermistor() {
 /*!
     @brief  Read Infrared sensor values
     @param  buf the array to place the pixels in
-    @param  size Optional number of bytes to read (up to 64). Default is 64
-   bytes.
-    @return up to 64 bytes of pixel data in buf
+    @param  pixels Optional number of pixels to read (up to 64). Default is
+   64 pixels.
+    @return up to 64 float values of pixel data in buf
 */
 /**************************************************************************/
-void Adafruit_AMG88xx::readPixels(float *buf, uint8_t size) {
+void Adafruit_AMG88xx::readPixels(float *buf, uint8_t pixels) {
   uint16_t recast;
   float converted;
   uint8_t bytesToRead =
-      min((uint8_t)(size << 1), (uint8_t)(AMG88xx_PIXEL_ARRAY_SIZE << 1));
+      min((uint8_t)(pixels << 1), (uint8_t)(AMG88xx_PIXEL_ARRAY_SIZE << 1));
   uint8_t rawArray[bytesToRead];
   this->read(AMG88xx_PIXEL_OFFSET, rawArray, bytesToRead);
 
-  for (int i = 0; i < size; i++) {
+  for (int i = 0; i < pixels; i++) {
     uint8_t pos = i << 1;
     recast = ((uint16_t)rawArray[pos + 1] << 8) | ((uint16_t)rawArray[pos]);
 

--- a/Adafruit_AMG88xx.cpp
+++ b/Adafruit_AMG88xx.cpp
@@ -171,7 +171,7 @@ float Adafruit_AMG88xx::readThermistor() {
 /*!
     @brief  Read Infrared sensor values
     @param  buf the array to place the pixels in
-    @param  size Optionsl number of bytes to read (up to 64). Default is 64
+    @param  size Optional number of bytes to read (up to 64). Default is 64
    bytes.
     @return up to 64 bytes of pixel data in buf
 */

--- a/Adafruit_AMG88xx.cpp
+++ b/Adafruit_AMG88xx.cpp
@@ -169,6 +169,22 @@ float Adafruit_AMG88xx::readThermistor() {
 
 /**************************************************************************/
 /*!
+    @brief  Read Infrared sensor raw values
+    @param  buf the array to place the pixels in
+    @param  pixels Optional number of pixels to read (up to 64). Default is
+   64 pixels. Each pixel value is 12 bits, so it is stored in 2 bytes of
+   the buf array,
+    @return up to 128 bytes of pixel data in buf
+*/
+/**************************************************************************/
+void Adafruit_AMG88xx::readPixelsRaw(uint8_t *buf, uint8_t pixels) {
+  uint8_t bytesToRead =
+      min((uint8_t)(pixels << 1), (uint8_t)(AMG88xx_PIXEL_ARRAY_SIZE << 1));
+  this->read(AMG88xx_PIXEL_OFFSET, buf, bytesToRead);
+}
+
+/**************************************************************************/
+/*!
     @brief  Read Infrared sensor values
     @param  buf the array to place the pixels in
     @param  pixels Optional number of pixels to read (up to 64). Default is

--- a/Adafruit_AMG88xx.h
+++ b/Adafruit_AMG88xx.h
@@ -74,7 +74,7 @@ public:
 
   bool begin(uint8_t addr = AMG88xx_ADDRESS, TwoWire *theWire = &Wire);
 
-  void readPixels(float *buf, uint8_t size = AMG88xx_PIXEL_ARRAY_SIZE);
+  void readPixels(float *buf, uint8_t pixels = AMG88xx_PIXEL_ARRAY_SIZE);
   float readThermistor();
 
   void setMovingAverageMode(bool mode);

--- a/Adafruit_AMG88xx.h
+++ b/Adafruit_AMG88xx.h
@@ -74,6 +74,7 @@ public:
 
   bool begin(uint8_t addr = AMG88xx_ADDRESS, TwoWire *theWire = &Wire);
 
+  void readPixelsRaw(uint8_t *buf, uint8_t pixels = AMG88xx_PIXEL_ARRAY_SIZE);
   void readPixels(float *buf, uint8_t pixels = AMG88xx_PIXEL_ARRAY_SIZE);
   float readThermistor();
 


### PR DESCRIPTION
The changes improve the readPixels() method readability and add the
readPixelsRaw() method to read the pixels' raw registers, that is useful in some
cases.

There aren't any known limitations with the changes.

The modifications have been tested with a local project, without problems.
